### PR TITLE
Fix a config path resolution bug on mac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ name = "ic-test-utils"
 version = "0.1.0"
 
 [dependencies]
-dirs = "4.0"
 garcon = "0.2"
 ic-agent = "0.11"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "ic-test-utils"
 version = "0.1.0"
 
 [dependencies]
+dirs = "4.0"
 garcon = "0.2"
 ic-agent = "0.11"
 serde = "1.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,10 @@ pub enum Error {
     #[error("Env var error: {0}")]
     EnvVar(#[from] std::env::VarError),
 
+    /// Certificate not found error
+    #[error("Certificate not found: {0}")]
+    CertNotFound(std::path::PathBuf),
+
     /// Serde json error
     #[error("Serde error: {0}")]
     Json(#[from] serde_json::Error),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,10 @@ pub enum Error {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// Std env var error
+    #[error("Env var error: {0}")]
+    EnvVar(#[from] std::env::VarError),
+
     /// Serde json error
     #[error("Serde error: {0}")]
     Json(#[from] serde_json::Error),

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -1,6 +1,5 @@
 //! Create and manage a ledger canister
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
 
 use ic_agent::ic_types::Principal;
 use ic_agent::identity::Identity;

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -31,14 +31,14 @@ pub const LEDGER_WASM: &[u8] = include_bytes!("ledger.wasm");
 /// # }
 /// ```
 pub struct LedgerBuilder {
-    owner: PathBuf,
+    owner: String,
     accounts: HashMap<AccountIdentifier, Tokens>,
 }
 
 impl LedgerBuilder {
-    fn new(owner: impl AsRef<Path>) -> Self {
+    fn new(owner: impl Into<String>) -> Self {
         Self {
-            owner: owner.as_ref().to_owned(),
+            owner: owner.into(),
             accounts: HashMap::new(),
         }
     }
@@ -50,7 +50,7 @@ impl LedgerBuilder {
         account_name: impl AsRef<str>,
         cycles: impl Into<Option<u64>>,
     ) -> Result<Principal> {
-        let owner = AccountIdentifier::new(get_identity(&self.owner)?.sender()?.into(), None);
+        let owner = AccountIdentifier::new(get_identity(&*self.owner)?.sender()?.into(), None);
 
         let initial_values = std::mem::take(&mut self.accounts);
 
@@ -74,10 +74,10 @@ impl LedgerBuilder {
     /// This is now the owner account. The owner account is set when calling [`new_ledger_canister`].
     pub fn with_account(
         &mut self,
-        account_name: impl AsRef<Path>,
+        account_name: impl Into<String>,
         tokens: Tokens,
     ) -> Result<&mut Self> {
-        let ident = super::get_identity(account_name)?;
+        let ident = super::get_identity(&*account_name.into())?;
         let principal = ident.sender()?;
         let account = AccountIdentifier::new(principal.into(), None);
         self.accounts.insert(account, tokens);
@@ -86,6 +86,6 @@ impl LedgerBuilder {
 }
 
 /// Create a new ledger canister through the [`LedgerBuilder`]
-pub fn new_ledger_canister(owner: impl AsRef<Path>) -> LedgerBuilder {
+pub fn new_ledger_canister(owner: impl Into<String>) -> LedgerBuilder {
     LedgerBuilder::new(owner)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,11 @@ const URL: &str = "http://localhost:8000";
 ///
 /// If this is ever needed outside of `get_agent` just make this
 /// function public.
-fn get_identity(account_name: impl AsRef<Path>) -> Result<BasicIdentity> {
-    let mut ident_path = dirs::config_dir().ok_or(crate::Error::MissingConfig)?;
-    ident_path.push("dfx/identity");
-    ident_path.push(account_name);
-    ident_path.push("identity.pem");
-
-    let identity = BasicIdentity::from_pem_file(ident_path)?;
+pub fn get_identity<'a>(account_name: impl Into<&'a str>) -> Result<BasicIdentity> {
+    let home_folder = std::env::var("HOME")?;
+    let account_name: &str = account_name.into();
+    let path_to = format!("{home_folder}/.config/dfx/identity/{account_name}/identity.pem");
+    let identity = BasicIdentity::from_pem_file(Path::new(&path_to))?;
     Ok(identity)
 }
 
@@ -44,7 +42,7 @@ fn get_identity(account_name: impl AsRef<Path>) -> Result<BasicIdentity> {
 /// mkdir -p ~/.config/dfx/identity/
 /// cp -Rn ./identity/.config/dfx/identity/* ~/.config/dfx/identity/
 /// ```
-pub async fn get_agent(name: impl AsRef<Path>, url: Option<&str>) -> Result<Agent> {
+pub async fn get_agent(name: impl Into<&str>, url: Option<&str>) -> Result<Agent> {
     let identity = get_identity(name)?;
 
     let url = url.unwrap_or(URL);


### PR DESCRIPTION
Problem: Currently we're using `dirs` crate to find a config
directory when reading dfx certificates. The problem is that
`dirs` authors decided to use

```
/Users/awkure/Library/Application Support/
```

as a config directory which is wrong in case of dfx.

Solution:
  * Rewrite `get_identity` to take path from $HOME
  * Make `LedgerBuilder` accept owner as `String`
  * Remove `dirs` dependency as it is no longer used