### PR TITLE
Pin `ic-agent` dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.2.0"
 [dependencies]
 dirs = "4.0"
 garcon = "0.2"
-ic-agent = "0.20"
+ic-agent = "=0.20.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_bytes = "0.11"


### PR DESCRIPTION
There was a [minor release](https://github.com/dfinity/agent-rs/blob/main/CHANGELOG.md#0201---2022-09-27) yesterday that obviously broke our dependency tree