### PR TITLE
[CPROD-1429] Fix Identity generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.2.0"
 [dependencies]
 dirs = "4.0"
 garcon = "0.2"
-ic-agent = "0.21"
+ic-agent = "0.23"
 serde = "1.0"
 serde_json = "1.0"
 serde_bytes = "0.11"

--- a/src/canister/management.rs
+++ b/src/canister/management.rs
@@ -1,7 +1,7 @@
 use candid::{encode_args, utils::ArgumentEncoder, CandidType, Deserialize, Encode, Principal};
 
 use super::{Agent, Canister};
-use crate::{get_waiter, Result};
+use crate::Result;
 
 /// The install mode of the canister to install. If a canister is already installed,
 /// using [InstallMode::Install] will be an error. [InstallMode::Reinstall] overwrites
@@ -82,7 +82,7 @@ impl<'agent> Canister<'agent, Management> {
         agent
             .update(&Principal::management_canister(), "install_code")
             .with_arg(args)
-            .call_and_wait(get_waiter())
+            .call_and_wait()
             .await?;
 
         Ok(())
@@ -137,7 +137,7 @@ impl<'agent> Canister<'agent, Management> {
         agent
             .update(&Principal::management_canister(), "stop_canister")
             .with_arg(arg)
-            .call_and_wait(get_waiter())
+            .call_and_wait()
             .await?;
         Ok(())
     }
@@ -153,7 +153,7 @@ impl<'agent> Canister<'agent, Management> {
         agent
             .update(&Principal::management_canister(), "delete_canister")
             .with_arg(arg)
-            .call_and_wait(get_waiter())
+            .call_and_wait()
             .await?;
         Ok(())
     }

--- a/src/canister/wallet.rs
+++ b/src/canister/wallet.rs
@@ -17,7 +17,6 @@ use candid::{CandidType, Decode, Deserialize, Encode, Principal};
 use ic_agent::{agent::UpdateBuilder, Agent};
 
 use super::Canister;
-use crate::get_waiter;
 use crate::{Error, Result};
 
 pub const WALLET_IDS_PATH: &str = "../../.dfx/local/wallets.json";
@@ -100,7 +99,7 @@ impl<'agent> Canister<'agent, Wallet> {
         };
         let mut builder = self.agent.update(self.principal(), "wallet_call");
         builder.with_arg(&Encode!(&call_forward_args)?);
-        let data = builder.call_and_wait(get_waiter()).await?;
+        let data = builder.call_and_wait().await?;
         let val = Decode!(&data, std::result::Result<CallResult, String>)??;
         Ok(val.payload)
     }
@@ -143,7 +142,7 @@ impl<'agent> Canister<'agent, Wallet> {
             },
         };
         builder.with_arg(&Encode!(&args)?);
-        let data = builder.call_and_wait(get_waiter()).await?;
+        let data = builder.call_and_wait().await?;
         let result = Decode!(&data, std::result::Result<CreateResult, String>)??;
         Ok(result.canister_id)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use candid::utils::ArgumentEncoder;
 use candid::Principal;
-use ic_agent::identity::BasicIdentity;
+use ic_agent::identity::Secp256k1Identity;
 use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, identity::PemError};
 
 pub use ic_agent::Agent;
@@ -23,13 +23,14 @@ const URL: &str = "http://localhost:8000";
 ///
 /// If this is ever needed outside of `get_agent` just make this
 /// function public.
-pub fn get_identity(account_name: impl AsRef<Path>) -> Result<BasicIdentity> {
+pub fn get_identity(account_name: impl AsRef<Path>) -> Result<Secp256k1Identity> {
     let mut ident_path = dirs::home_dir().ok_or(crate::Error::MissingConfig)?;
     ident_path.push(".config");
     ident_path.push("dfx/identity");
     ident_path.push(account_name);
     ident_path.push("identity.pem");
-    match BasicIdentity::from_pem_file(&ident_path) {
+
+    match Secp256k1Identity::from_pem_file(&ident_path) {
         Ok(identity) => Ok(identity),
         Err(PemError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
             Err(Error::CertNotFound(ident_path))
@@ -65,7 +66,7 @@ pub async fn get_agent(name: impl Into<&str>, url: Option<&str>) -> Result<Agent
 }
 
 /// Create a default `Delay` with a throttle of 500ms
-/// and a timout of five minutes.
+/// and a timeout of five minutes.
 pub fn get_waiter() -> garcon::Delay {
     garcon::Delay::builder()
         .throttle(std::time::Duration::from_millis(500))


### PR DESCRIPTION
The new dfx version generates new identities based on `Secp256k1` cryptography, this PR migrates to that which should be able to fix CI, to avoid any errors in the local development, I suggest that you delete the old identities and let the script generate the new EC identities for you.