### PR TITLE
Wasm install bytecode does not need to be moved

### DIFF
--- a/src/canister/management.rs
+++ b/src/canister/management.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
-use candid::{encode_args, utils::ArgumentEncoder, CandidType, Deserialize, Encode, Principal};
+use candid::utils::ArgumentEncoder;
+use candid::{encode_args, CandidType, Deserialize, Encode, Principal};
 
 use super::{Agent, Canister};
 use crate::Result;
@@ -66,7 +67,7 @@ impl<'agent> Canister<'agent, Management> {
         Self::new(id, agent)
     }
 
-    async fn _install_code<'wallet_agent, T: ArgumentEncoder>(
+    async fn _install_code<T: ArgumentEncoder>(
         &self,
         agent: &Agent,
         canister_id: Principal,

--- a/src/canister/management.rs
+++ b/src/canister/management.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use candid::{encode_args, utils::ArgumentEncoder, CandidType, Deserialize, Encode, Principal};
 
 use super::{Agent, Canister};
@@ -21,14 +23,15 @@ pub enum InstallMode {
 
 /// Installation arguments for [`Canister::install_code`].
 #[derive(CandidType, Deserialize)]
-pub struct CanisterInstall {
+pub struct CanisterInstall<'a> {
     /// [`InstallMode`]
     pub mode: InstallMode,
     /// Canister id
     pub canister_id: Principal,
-    #[serde(with = "serde_bytes")]
     /// Wasm module as raw bytes
-    pub wasm_module: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    #[serde(borrow)]
+    pub wasm_module: Cow<'a, [u8]>,
     #[serde(with = "serde_bytes")]
     /// Any aditional arguments to be passed along
     pub arg: Vec<u8>,
@@ -49,7 +52,7 @@ struct In {
 /// ```
 /// # use ic_agent::Agent;
 /// use ic_test_utils::canister::Canister;
-/// # async fn run(agent: &Agent, principal: ic_cdk::export::candid::Principal) {
+/// # async fn run(agent: &Agent, principal: candid::Principal) {
 /// let management = Canister::new_management(agent);
 /// management.stop_canister(&agent, principal).await;
 /// # }
@@ -67,7 +70,7 @@ impl<'agent> Canister<'agent, Management> {
         &self,
         agent: &Agent,
         canister_id: Principal,
-        bytecode: Vec<u8>,
+        bytecode: Cow<'_, [u8]>,
         mode: InstallMode,
         arg: T,
     ) -> Result<()> {
@@ -94,7 +97,7 @@ impl<'agent> Canister<'agent, Management> {
         &self,
         agent: &Agent,
         canister_id: Principal,
-        bytecode: Vec<u8>,
+        bytecode: Cow<'_, [u8]>,
         arg: T,
     ) -> Result<()> {
         self._install_code(agent, canister_id, bytecode, InstallMode::Install, arg)
@@ -107,7 +110,7 @@ impl<'agent> Canister<'agent, Management> {
         &self,
         agent: &Agent,
         canister_id: Principal,
-        bytecode: Vec<u8>,
+        bytecode: Cow<'_, [u8]>,
         arg: T,
     ) -> Result<()> {
         self._install_code(agent, canister_id, bytecode, InstallMode::Reinstall, arg)
@@ -120,7 +123,7 @@ impl<'agent> Canister<'agent, Management> {
         &self,
         agent: &Agent,
         canister_id: Principal,
-        bytecode: Vec<u8>,
+        bytecode: Cow<'_, [u8]>,
         arg: T,
     ) -> Result<()> {
         self._install_code(agent, canister_id, bytecode, InstallMode::Upgrade, arg)

--- a/src/canister/mod.rs
+++ b/src/canister/mod.rs
@@ -3,7 +3,7 @@
 //! ```
 //! use ic_test_utils::canister::Canister;
 //!
-//! # async fn run<'a, T>(canister: Canister<'a, T>, principal: ic_cdk::export::candid::Principal, agent: &'a ic_agent::Agent) {
+//! # async fn run<'a, T>(canister: Canister<'a, T>, principal: candid::Principal, agent: &'a ic_agent::Agent) {
 //! let wallet = Canister::new_wallet(agent, "bob", None).unwrap();
 //! let management = Canister::new_management(agent);
 //! # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
+use std::borrow::Cow;
 use std::path::Path;
 
 use candid::utils::ArgumentEncoder;
@@ -79,7 +80,7 @@ pub fn get_waiter() -> garcon::Delay {
 pub async fn create_canister<T: ArgumentEncoder>(
     agent: &Agent,
     account_name: impl AsRef<str>,
-    bytecode: Vec<u8>,
+    bytecode: Cow<'_, [u8]>,
     arg: T,
     cycles: u64,
 ) -> Result<Principal> {


### PR DESCRIPTION
A canister bytecode can be several MB big, there's no need to move it when the canister is installed. This avoids cloning it when used in multiple tests